### PR TITLE
add project switcher so we can store requests in their projects repository or custom paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Gostman automatically manages API collections per project directory:
 
 #### Dashboard Navigation
 - **p**: Toggle project view
-- **a**: Create new project (when in project view)
 - **r**: Remove selected project (when in project view)
 - **n**: Create new request
 - **d**: Delete selected request

--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ A terminal-based API client built with Bubble Tea for creating, sending, and man
 
 ## ✨ Features
 
-- Create and send HTTP requests (GET, POST, PUT, DELETE, etc.).
-- Save, load, and manage requests.
-- Edit and delete saved requests easily.
-- Dynamic UI with support for status messages, and detailed responses.
+- Create and send HTTP requests (GET, POST, PUT, DELETE, etc.)
+- Save, load, and manage requests
+- Edit and delete saved requests easily
+- Dynamic UI with support for status messages, and detailed responses
+- **Project Management**: Automatically detects and manages API collections per directory
+- **Multi-project support**: Track and switch between different projects
+- **Environment variables**: Support for dynamic request configuration
 
 ## 📥 Install
 
@@ -26,20 +29,68 @@ _If you have Go already, install the executable yourself_
 
 ## 🧑‍💻 Usage 
 
-### Use keyboard shortcuts to interact with the UI:
+### Project Management
 
-- Ctrl + C: Quit the application.
-- Tab: Move Around
-- Ctrl + Arrow Keys: Change Tabs (Body/Param/Header)
-- Enter: Send a request.
-- Ctrl + S: Save the current request.
-- Ctrl + E: Open Environment Variables page
-- Ctrl + D: Open Dashboard.
-- Ctrl + H: Open Help page
+Gostman automatically manages API collections per project directory:
+1. When you run `gostman`, it checks for a `gostman.json` file in your current directory
+2. If found, it automatically loads that project's requests
+3. If not found, it prompts you to create a new project or use an existing one
+4. Each directory can have its own collection of API requests
+
+### Keyboard Shortcuts
+
+#### Main Interface
+- **Ctrl + C**: Quit the application
+- **Tab**: Navigate between fields (Name, Method, URL, Content tabs)
+- **Shift + ←/→**: Switch between content tabs (Body/Params/Headers)
+- **Enter**: Send the current request
+- **Ctrl + S**: Save the current request
+
+#### Project Management
+- **Ctrl + P**: Quick project switcher
+- **Ctrl + D**: Open main dashboard
+
+#### Dashboard Navigation
+- **p**: Toggle project view
+- **a**: Create new project (when in project view)
+- **r**: Remove selected project (when in project view)
+- **n**: Create new request
+- **d**: Delete selected request
+- **Enter**: Load selected request or switch to selected project
+
+#### Other Features
+- **Ctrl + E**: Open Environment Variables editor
+- **Ctrl + H**: Open Help page
+- **Esc**: Go back/cancel current action
+
+### Project Workflow
+
+#### Creating a New Project
+1. Navigate to your project directory
+2. Run `gostman`
+3. Choose "y" to create a new `gostman.json` file
+4. Start creating and saving requests
+
+#### Switching Between Projects
+1. Use **Ctrl + P** for quick project switching
+2. Or use **Ctrl + D** → **p** to browse all projects
+3. Select any project to switch to it instantly
+
+#### Managing Requests
+- Requests are automatically saved to the current project's `gostman.json`
+- Each project maintains its own collection of requests
+- Use the dashboard (**Ctrl + D**) to browse, edit, and delete saved requests
+
+### Environment Variables
+
+Use environment variables to make your requests dynamic:
+1. Press **Ctrl + E** to open the environment editor
+2. Define variables in JSON format: `{"baseUrl": "https://api.example.com"}`
+3. Use variables in requests with double braces: `{{baseUrl}}/users`
 
 ### Saving and Loading Requests 
 
-Requests are saved as JSON files in the user's home directory under a dedicated folder. The JSON file structure allows for efficient updates and deletions.
+Requests are saved as JSON files in your project directory or user's home directory. The JSON file structure allows for efficient updates and deletions. Each project maintains its own `gostman.json` file with requests and environment variables.
 
 ## 🤝 Contributing
 

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -3,10 +3,13 @@ package cmd
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 type listItem struct {
@@ -17,13 +20,36 @@ func (i listItem) Title() string       { return i.request.Name }
 func (i listItem) Description() string { return i.request.Method }
 func (i listItem) FilterValue() string { return i.request.Name }
 
+type projectItem struct {
+	project Project
+}
+
+func (i projectItem) Title() string       { 
+	title := i.project.Name
+	if i.project.Path == GetCurrentProject() {
+		return "• " + title + " (current)"
+	}
+	return "  " + title
+}
+func (i projectItem) Description() string { 
+	if i.project.Path == GetCurrentProject() {
+		return "→ " + i.project.Path
+	}
+	return "  " + i.project.Path 
+}
+func (i projectItem) FilterValue() string { return i.project.Name }
+
 type board struct {
 	width       int
 	height      int
 	styles      *Styles
 	list        list.Model
 	returnModel *Model
-	showMsg     bool
+	showMsg        bool
+	showProjects   bool
+	projectList    list.Model
+	showInput      bool
+	projectInput   textinput.Model
 }
 
 func dashboard(width, height int, styles *Styles, returnModel *Model) board {
@@ -60,9 +86,32 @@ func dashboard(width, height int, styles *Styles, returnModel *Model) board {
 		return []key.Binding{
 			Keymap.Create,
 			Keymap.Delete,
+			Keymap.Paths,
 			Keymap.Back,
 		}
 	}
+
+	// Initialize project list
+	var projectItems []list.Item
+	for _, project := range GetProjects() {
+		projectItems = append(projectItems, projectItem{project: project})
+	}
+	
+	board.projectList = list.New(projectItems, list.NewDefaultDelegate(), width, height-3)
+	board.projectList.Title = "Projects"
+	board.projectList.SetShowStatusBar(false)
+	board.projectList.SetFilteringEnabled(false)
+	board.projectList.Styles.Title = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("#FAFAFA")).
+		Background(lipgloss.Color("#7D56F4")).
+		Padding(0, 1)
+
+	// Initialize project input
+	board.projectInput = textinput.New()
+	board.projectInput.Placeholder = "Enter project name..."
+	board.projectInput.Width = width - 10
+	board.projectInput.CharLimit = 200
 
 	return board
 }
@@ -78,21 +127,54 @@ func (m board) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 		if msg.String() == "esc" {
+			if m.showInput {
+				m.showInput = false
+				m.projectInput.Blur()
+				return m, nil
+			}
 			m.returnModel.height = m.height
 			m.returnModel.width = m.width
 			return m.returnModel, nil
 		}
 		if msg.String() == "enter" {
-			data := m.list.SelectedItem().(listItem)
-			newModel := NewModel()
-			load(data.request, &newModel)
-			newModel.width = m.width
-			newModel.height = m.height
-			newModel.styles = m.styles
-			return newModel, nil
+			if m.showInput {
+				// Create new project
+				projectName := m.projectInput.Value()
+				if projectName != "" {
+					if err := CreateProjectInCurrentDir(); err != nil {
+						// Show error message and stay in input mode
+						m.projectInput.SetValue("")
+						m.projectInput.Placeholder = "Error: " + err.Error() + " - Try again..."
+						return m, nil
+					}
+					m.showInput = false
+					m.showProjects = false
+					// Refresh the dashboard with new data
+					return dashboard(m.width, m.height, m.styles, m.returnModel), nil
+				}
+			} else if m.showProjects {
+				// Switch project
+				data := m.projectList.SelectedItem().(projectItem)
+				if err := SetCurrentProject(data.project.Path); err != nil {
+					// If there's an error, just stay on current selection
+					return m, nil
+				}
+				m.showProjects = false
+				// Refresh the dashboard with new data
+				return dashboard(m.width, m.height, m.styles, m.returnModel), nil
+			} else {
+				// Load request
+				data := m.list.SelectedItem().(listItem)
+				newModel := NewModel()
+				load(data.request, &newModel)
+				newModel.width = m.width
+				newModel.height = m.height
+				newModel.styles = m.styles
+				return newModel, nil
+			}
 		}
 		if msg.String() == "n" {
-			if !m.showMsg {
+			if !m.showMsg && !m.showProjects && !m.showInput {
 				newModel := NewModel()
 				newModel.width = m.width
 				newModel.height = m.height
@@ -100,7 +182,28 @@ func (m board) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return newModel, nil
 			}
 		}
-		if msg.String() == "d" && !m.showMsg {
+		if msg.String() == "p" && !m.showMsg {
+			m.showProjects = !m.showProjects
+			m.showInput = false
+			return m, nil
+		}
+		if msg.String() == "a" && !m.showMsg && m.showProjects {
+			m.showInput = true
+			m.projectInput.SetValue("")
+			m.projectInput.Focus()
+			return m, nil
+		}
+		if msg.String() == "r" && !m.showMsg && m.showProjects && !m.showInput {
+			// Remove selected project
+			data := m.projectList.SelectedItem().(projectItem)
+			if err := RemoveProject(data.project.Path); err != nil {
+				// Show error message briefly (could implement a temporary message system)
+				return m, nil
+			}
+			// Refresh the dashboard
+			return dashboard(m.width, m.height, m.styles, m.returnModel), nil
+		}
+		if msg.String() == "d" && !m.showMsg && !m.showProjects && !m.showInput {
 			// Show message before deleting
 			m.showMsg = true
 			return m, nil
@@ -140,16 +243,72 @@ func (m board) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	var cmd tea.Cmd
-	m.list, cmd = m.list.Update(msg)
+	if m.showInput {
+		m.projectInput, cmd = m.projectInput.Update(msg)
+	} else if m.showProjects {
+		m.projectList, cmd = m.projectList.Update(msg)
+	} else {
+		m.list, cmd = m.list.Update(msg)
+	}
 	return m, cmd
 }
 
 func (m board) View() string {
-	footer := m.appBoundaryMessage("Ctrl+c to quit, <ESC> to go back")
-	if m.showMsg {
-		footer = m.appBoundaryMessage("Delete selected item? : (Y/N)")
+	var footer string
+	var body string
+	
+	if m.showInput {
+		footer = m.appBoundaryMessage("Create project in current dir • <ESC> to cancel")
+		inputView := "Create New Project:\n\n" + m.projectInput.View()
+		body = borderStyle.Width(m.width - 2).Render(inputView)
+	} else if m.showProjects {
+		footer = m.appBoundaryMessage("↑↓ navigate • enter to select • a to create • r to remove • esc to cancel")
+		
+		projectHeader := lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#FAFAFA")).
+			Background(lipgloss.Color("#7D56F4")).
+			Padding(0, 1).
+			Width(m.width - 4).
+			Render("Switch Project")
+		
+		projectContent := lipgloss.JoinVertical(lipgloss.Left, projectHeader, "", m.projectList.View())
+		body = borderStyle.Width(m.width - 2).Render(projectContent)
+	} else {
+		// Main view with project selector
+		currentProject := GetCurrentProject()
+		var projectName string
+		if currentProject == "" {
+			projectName = "Default"
+		} else {
+			projectName = filepath.Base(currentProject)
+			// Find project name from config
+			for _, p := range GetProjects() {
+				if p.Path == currentProject {
+					projectName = p.Name
+					break
+				}
+			}
+		}
+		
+		// Create project selector header similar to lazygit
+		projectSelector := lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#FAFAFA")).
+			Background(lipgloss.Color("#7D56F4")).
+			Padding(0, 1).
+			Width(m.width - 4).
+			Render("Project: " + projectName + " (press 'p' to switch)")
+		
+		footer = m.appBoundaryMessage("Ctrl+c to quit • <ESC> to go back • p for projects")
+		if m.showMsg {
+			footer = m.appBoundaryMessage("Delete selected item? : (Y/N)")
+		}
+		
+		listView := m.list.View()
+		content := lipgloss.JoinVertical(lipgloss.Left, projectSelector, "", listView)
+		body = borderStyle.Width(m.width - 2).Render(content)
 	}
-
-	body := borderStyle.Width(m.width - 2).Render(m.list.View())
+	
 	return m.styles.Base.Render(body + "\n" + footer)
 }

--- a/cmd/data.go
+++ b/cmd/data.go
@@ -17,6 +17,16 @@ type SavedData struct {
 	Requests  []Request `json:"requests"`
 }
 
+type Config struct {
+	CurrentProject string    `json:"currentProject"`
+	Projects       []Project `json:"projects"`
+}
+
+type Project struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
 // Request represents the structure of a single saved request
 type Request struct {
 	Id          string `json:"id"`
@@ -30,7 +40,20 @@ type Request struct {
 }
 
 var appFolder = getAppDataPath()
-var jsonfilePath = filepath.Join(appFolder, "gostman.json")
+var configPath = filepath.Join(appFolder, "config.json")
+var config *Config
+var jsonfilePath string
+
+func init() {
+	config = loadConfig()
+	// Use configured current project or default
+	if config.CurrentProject != "" {
+		jsonfilePath = filepath.Join(config.CurrentProject, "gostman.json")
+	} else {
+		// Fall back to app folder
+		jsonfilePath = filepath.Join(appFolder, "gostman.json")
+	}
+}
 
 func getAppDataPath() string {
 	if runtime.GOOS == "windows" {
@@ -38,6 +61,181 @@ func getAppDataPath() string {
 	}
 	// Linux and macOS path: ~/.local/share/Gostman
 	return filepath.Join(os.Getenv("HOME"), ".local", "share", "Gostman")
+}
+
+func loadConfig() *Config {
+	// Ensure app folder exists
+	if err := os.MkdirAll(appFolder, os.ModePerm); err != nil {
+		fmt.Println("Failed to create app directory:", err)
+	}
+
+	// Check if config file exists
+	if checkFileExists(configPath) {
+		// Create default config
+		cfg := &Config{
+			CurrentProject: "",
+			Projects:       []Project{},
+		}
+		saveConfig(cfg)
+		return cfg
+	}
+
+	// Load existing config
+	file, err := os.ReadFile(configPath)
+	if err != nil {
+		fmt.Println("Error reading config:", err)
+		// Return default config on error
+		return &Config{
+			CurrentProject: "",
+			Projects:       []Project{},
+		}
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(file, &cfg); err != nil {
+		fmt.Println("Error parsing config:", err)
+		// Return default config on error
+		return &Config{
+			CurrentProject: "",
+			Projects:       []Project{},
+		}
+	}
+
+	return &cfg
+}
+
+func saveConfig(cfg *Config) {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		fmt.Println("Error encoding config:", err)
+		return
+	}
+
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		fmt.Println("Error saving config:", err)
+	}
+}
+
+func addProjectIfNotExists(name, path string) {
+	for _, project := range config.Projects {
+		if project.Path == path {
+			return // Already exists
+		}
+	}
+	config.Projects = append(config.Projects, Project{
+		Name: name,
+		Path: path,
+	})
+}
+
+func SetCurrentProject(projectPath string) error {
+	// Validate the path
+	if projectPath == "" {
+		return fmt.Errorf("project path cannot be empty")
+	}
+	
+	// Ensure the directory exists
+	if err := os.MkdirAll(projectPath, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+	
+	gostmanFile := filepath.Join(projectPath, "gostman.json")
+	
+	// If file doesn't exist, create it with empty structure
+	if checkFileExists(gostmanFile) {
+		emptyData := SavedData{
+			Variables: "",
+			Requests:  []Request{},
+		}
+		data, err := json.MarshalIndent(emptyData, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to create initial data: %w", err)
+		}
+		if err := os.WriteFile(gostmanFile, data, 0644); err != nil {
+			return fmt.Errorf("failed to create file: %w", err)
+		}
+	}
+	
+	config.CurrentProject = projectPath
+	jsonfilePath = gostmanFile
+	
+	// Add to projects if not already present
+	addProjectIfNotExists(filepath.Base(projectPath), projectPath)
+	
+	saveConfig(config)
+	return nil
+}
+
+func GetCurrentProject() string {
+	return config.CurrentProject
+}
+
+func GetProjects() []Project {
+	return config.Projects
+}
+
+func RemoveProject(projectPath string) error {
+	// Don't allow removing the current project if it's the only one
+	if len(config.Projects) <= 1 {
+		return fmt.Errorf("cannot remove the only project")
+	}
+	
+	// Find and remove the project
+	found := false
+	newProjects := make([]Project, 0, len(config.Projects)-1)
+	for _, p := range config.Projects {
+		if p.Path != projectPath {
+			newProjects = append(newProjects, p)
+		} else {
+			found = true
+		}
+	}
+	
+	if !found {
+		return fmt.Errorf("project not found in configuration")
+	}
+	
+	config.Projects = newProjects
+	
+	// If we removed the current project, switch to the first available project
+	if config.CurrentProject == projectPath {
+		if len(config.Projects) > 0 {
+			config.CurrentProject = config.Projects[0].Path
+			jsonfilePath = filepath.Join(config.CurrentProject, "gostman.json")
+		} else {
+			config.CurrentProject = ""
+			jsonfilePath = filepath.Join(appFolder, "gostman.json")
+		}
+	}
+	
+	saveConfig(config)
+	return nil
+}
+
+func CreateProjectInCurrentDir() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+	
+	// Use directory name as project name
+	projectName := filepath.Base(cwd)
+	
+	// Ensure the project is added with proper name
+	if err := SetCurrentProject(cwd); err != nil {
+		return err
+	}
+	
+	// Update the project name in config
+	for i, project := range config.Projects {
+		if project.Path == cwd {
+			config.Projects[i].Name = projectName
+			break
+		}
+	}
+	saveConfig(config)
+	
+	return nil
 }
 
 func SaveRequests(request Request) {

--- a/cmd/model.go
+++ b/cmd/model.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -86,7 +88,7 @@ func NewModel() Model {
 	m.spinner = spinner.New()
 	m.spinner.Spinner = spinner.Dot
 	m.spinner.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("#E03535"))
-	m.message = m.appBoundaryView("Ctrl+c to quit, Ctrl+h for help")
+	m.message = m.appBoundaryView("Ctrl+c to quit, Ctrl+h for help, Ctrl+p for projects")
 	m.loading = false
 
 	return m
@@ -146,6 +148,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+d":
 			dashboard := dashboard(m.width, m.height, m.styles, &m)
 			return dashboard, nil
+		case "ctrl+p":
+			dashboardModel := dashboard(m.width, m.height, m.styles, &m)
+			dashboardModel.showProjects = true
+			return dashboardModel, nil
 		case "ctrl+s":
 
 			m.loading = true
@@ -164,7 +170,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "tab":
 			m.focused = (m.focused + 1) % len(m.fields)
-			m.message = m.appBoundaryView("Ctrl+c to quit, Ctrl+h for help")
+			m.message = m.appBoundaryView("Ctrl+c to quit, Ctrl+h for help, Ctrl+p for projects")
 		}
 	}
 
@@ -228,6 +234,39 @@ func (m Model) View() string {
 
 	var footer string
 
+	// Create project selector header
+	currentProject := GetCurrentProject()
+	projects := GetProjects()
+	var projectName string
+	if currentProject == "" {
+		projectName = "Default"
+	} else {
+		projectName = filepath.Base(currentProject)
+		// Find project name from config
+		for _, p := range projects {
+			if p.Path == currentProject {
+				projectName = p.Name
+				break
+			}
+		}
+	}
+	
+	projectCount := len(projects)
+	var projectInfo string
+	if projectCount == 0 {
+		projectInfo = "Project: " + projectName + " (no projects)"
+	} else {
+		projectInfo = "Project: " + projectName + " (" + fmt.Sprintf("%d", projectCount) + " total) - Ctrl+P to switch"
+	}
+	
+	projectSelector := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("#FAFAFA")).
+		Background(lipgloss.Color("#7D56F4")).
+		Padding(0, 1).
+		Width(m.width - 2).
+		Render(projectInfo)
+
 	doc := strings.Builder{}
 	var renderedTabs []string
 
@@ -257,7 +296,7 @@ func (m Model) View() string {
 
 	tabContent := lipgloss.NewStyle().
 		Width(tabContentWidth - 2).
-		Height(m.height - 8).
+		Height(m.height - 10).
 		Render(m.tabContent[m.activeTab].View())
 
 	combined := lipgloss.JoinVertical(lipgloss.Left, tabRow, tabContent)
@@ -268,10 +307,10 @@ func (m Model) View() string {
 	doc.WriteString(finalPanel)
 	requestPanel := doc.String()
 
-	m.responseViewport.Height = m.height - 7
+	m.responseViewport.Height = m.height - 9
 	m.responseViewport.Width = m.width - tabContentWidth - 2
 
-	responsePanel := borderStyle.Width(m.width - tabContentWidth - 2).Height(m.height - 6).Render(titleStyle.Render(" Response: ") + headingStyle.Render(m.status) + "\n" + m.responseViewport.View())
+	responsePanel := borderStyle.Width(m.width - tabContentWidth - 2).Height(m.height - 8).Render(titleStyle.Render(" Response: ") + headingStyle.Render(m.status) + "\n" + m.responseViewport.View())
 	mainPanel := lipgloss.JoinHorizontal(lipgloss.Left, requestPanel, responsePanel)
 
 	nameStyle := borderStyle
@@ -306,7 +345,7 @@ func (m Model) View() string {
 
 	topPanel := lipgloss.JoinHorizontal(lipgloss.Left, nameInput, methodInput, urlInput)
 
-	body := lipgloss.JoinVertical(lipgloss.Top, topPanel, mainPanel)
+	body := lipgloss.JoinVertical(lipgloss.Top, projectSelector, "", topPanel, mainPanel)
 
 	if m.loading {
 		spinnerView := m.spinner.View()
@@ -321,6 +360,6 @@ func (m Model) View() string {
 func (m *Model) sizeInputs() {
 	for i := range m.tabContent {
 		m.tabContent[i].SetWidth(int(float64(m.width)*0.5) - 2)
-		m.tabContent[i].SetHeight(m.height - 8)
+		m.tabContent[i].SetHeight(m.height - 10)
 	}
 }

--- a/cmd/startup.go
+++ b/cmd/startup.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type startupModel struct {
+	width    int
+	height   int
+	styles   *Styles
+	showPrompt bool
+	currentDir string
+}
+
+func NewStartupModel() startupModel {
+	cwd, _ := os.Getwd()
+	gostmanFile := filepath.Join(cwd, "gostman.json")
+	
+	m := startupModel{
+		width:      80,
+		height:     24,
+		showPrompt: checkFileExists(gostmanFile),
+		currentDir: cwd,
+	}
+	
+	lg := lipgloss.DefaultRenderer()
+	m.styles = NewStyles(lg)
+	
+	return m
+}
+
+type transitionMsg struct{}
+
+func (m startupModel) Init() tea.Cmd {
+	if !m.showPrompt {
+		// File exists, transition immediately
+		return func() tea.Msg {
+			return transitionMsg{}
+		}
+	}
+	return nil
+}
+
+func (m startupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+	case transitionMsg:
+		// File exists, set current project and transition
+		if err := SetCurrentProject(m.currentDir); err != nil {
+			// Handle error - continue anyway
+		}
+		mainModel := NewModel()
+		mainModel.width = m.width
+		mainModel.height = m.height
+		return mainModel, nil
+	case tea.KeyMsg:
+		if m.showPrompt {
+			switch msg.String() {
+			case "ctrl+c", "q":
+				return m, tea.Quit
+			case "y", "Y":
+				// Create gostman.json in current directory
+				if err := CreateProjectInCurrentDir(); err != nil {
+					// Handle error - for now just continue to main app
+				}
+				// Switch to main model
+				mainModel := NewModel()
+				mainModel.width = m.width
+				mainModel.height = m.height
+				return mainModel, nil
+			case "n", "N":
+				// Continue to main app without creating file - use latest project if available
+				if config.CurrentProject != "" {
+					// Latest project is already set in config, just ensure jsonfilePath is correct
+					jsonfilePath = filepath.Join(config.CurrentProject, "gostman.json")
+				} else if len(config.Projects) > 0 {
+					// No current project but we have projects, use the first one
+					if err := SetCurrentProject(config.Projects[0].Path); err != nil {
+						// If error, fall back to default app folder
+					}
+				} else {
+					// No projects at all, create a default one in app folder
+					defaultProject := filepath.Join(appFolder, "default")
+					if err := SetCurrentProject(defaultProject); err != nil {
+						// If error, continue with app folder fallback
+					}
+				}
+				mainModel := NewModel()
+				mainModel.width = m.width
+				mainModel.height = m.height
+				return mainModel, nil
+			}
+		}
+	}
+	
+	return m, nil
+}
+
+func (m startupModel) View() string {
+	if !m.showPrompt {
+		// File exists, return empty as we're transitioning
+		return ""
+	}
+
+	// Show creation prompt
+	title := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("#FAFAFA")).
+		Background(lipgloss.Color("#7D56F4")).
+		Padding(0, 1).
+		Render("Gostman")
+
+	// Determine what will happen if user chooses "no"
+	fallbackText := "Use default project"
+	if config.CurrentProject != "" {
+		fallbackText = "Use: " + filepath.Base(config.CurrentProject)
+	} else if len(config.Projects) > 0 {
+		fallbackText = "Use: " + config.Projects[0].Name
+	}
+
+	prompt := lipgloss.NewStyle().
+		Width(60).
+		Align(lipgloss.Center).
+		Render("No gostman.json found in current directory.\n\nWould you like to create one?\n\n(y) Create new project here\n(n) " + fallbackText + "\n\nChoice:")
+
+	footer := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#626262")).
+		Render("Press Ctrl+C to quit")
+
+	content := lipgloss.JoinVertical(
+		lipgloss.Center,
+		title,
+		"\n",
+		prompt,
+		"\n",
+		footer,
+	)
+
+	return lipgloss.Place(
+		m.width,
+		m.height,
+		lipgloss.Center,
+		lipgloss.Center,
+		content,
+	)
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -128,6 +128,9 @@ type keymap struct {
 	Delete key.Binding
 	Back   key.Binding
 	Quit   key.Binding
+	Paths  key.Binding
+	Add    key.Binding
+	Switch key.Binding
 }
 
 // Keymap reusable key mappings shared across models
@@ -147,5 +150,17 @@ var Keymap = keymap{
 	Quit: key.NewBinding(
 		key.WithKeys("ctrl+c", "q"),
 		key.WithHelp("ctrl+c/q", "quit"),
+	),
+	Paths: key.NewBinding(
+		key.WithKeys("p"),
+		key.WithHelp("p", "projects"),
+	),
+	Add: key.NewBinding(
+		key.WithKeys("a"),
+		key.WithHelp("a", "add"),
+	),
+	Switch: key.NewBinding(
+		key.WithKeys("ctrl+p"),
+		key.WithHelp("ctrl+p", "switch project"),
 	),
 }

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	p := tea.NewProgram(cmd.NewModel(),
+	p := tea.NewProgram(cmd.NewStartupModel(),
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(),
 	)


### PR DESCRIPTION
On startup, we're asking if we should create a new project if none exists:
![CleanShot 2025-05-23 at 23 31 34@2x](https://github.com/user-attachments/assets/8b149560-1ab7-4a6c-b636-f8a7b5ddf2c0)

New project indicator at the top:
![CleanShot 2025-05-23 at 23 32 04@2x](https://github.com/user-attachments/assets/defa2004-5b1d-474a-bf79-38a18bdbca6c)

project switcher view
![CleanShot 2025-05-23 at 23 32 30@2x](https://github.com/user-attachments/assets/2ca1d41a-c7f9-468e-8a0f-fb88466ae830)
