### PR TITLE
feat: add auto-completion and `OPTIONS` request method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A terminal-based API client built with Bubble Tea for creating, sending, and man
 - Save, load, and manage requests.
 - Edit and delete saved requests easily.
 - Dynamic UI with support for status messages, and detailed responses.
+- Auto-completion for Name/URL fields from your previous inputs.
 
 ## 📥 Install
 
@@ -68,7 +69,7 @@ sudo nixos-rebuild switch && gostman
 
 ## 🧑‍💻 Usage
 
-### Use keyboard shortcuts to interact with the UI:
+### Use keyboard shortcuts to interact with the UI
 
 - Ctrl + C: Quit the application.
 - Tab: Move Around
@@ -78,6 +79,8 @@ sudo nixos-rebuild switch && gostman
 - Ctrl + E: Open Environment Variables page
 - Ctrl + D: Open Dashboard.
 - Ctrl + H: Open Help page
+- Ctrl + Space / Ctrl + @ / Ctrl + F: Auto-complete Name/URL from history
+- Up/Down on Method: Cycle HTTP method
 
 ### Saving and Loading Requests
 

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -9,11 +9,15 @@ import (
 )
 
 const commandsContent = `tab = Move Around
+shift + tab = Move Backwards
 enter = Send Request
 ctrl + s = Save Request								
 shift + Arrow Keys = Change Tabs (Body/Param/Header)
 ctrl + e = Open Environment Variables page
 ctrl + d = Open dashboard
+ctrl + y = Copy Response to Clipboard
+ctrl + f = Auto-complete Name/URL from history
+up/down on Method = Cycle HTTP method
 ctrl + c = Quit`
 
 func createCommandRows() []table.Row {

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -207,6 +207,31 @@ func send(m Model) (string, string) {
 
 		return string(body), resp.Status
 
+	case "OPTIONS":
+		client := &http.Client{}
+		req, err := http.NewRequest("OPTIONS", URL, nil)
+		if err != nil {
+			return "Failed to make request\n\n" + err.Error(), ""
+		}
+
+		// Set headers
+		for key, value := range headers {
+			req.Header.Set(key, value)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return "Failed to make request\n\n" + err.Error(), ""
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "Failed to read response body\n\n" + err.Error(), ""
+		}
+
+		return string(body), resp.Status
+
 	default:
 		return "Request Method or Url is set incorrectly", " Incorrect Request "
 	}


### PR DESCRIPTION
# PR Summary

Adds **inline history-based autocomplete** for Name/URL fields, a **keyboard-driven HTTP method selector**, and support for the **`OPTIONS` method**, along with updated help/docs. Improves speed and ergonomics without changing layout.

## User-visible changes

* **Autocomplete (Name/URL)**

  * Footer hint suggests best match from history.
  * `Ctrl+F` accepts suggestion instantly.

* **HTTP method selector**

  * `Up`/`Down` cycle through methods.
  * `Left`/`Right` keep cursor movement.
  * Added support for `OPTIONS`.

* **Help/docs**

  * Added `Ctrl+F`, `Ctrl+Y`, `Shift+tab` and method cycling notes.

## New shortcuts

* `Ctrl+F`: accept autocomplete
* `Up`/`Down`: cycle method

## Implementation

* Inline helpers: `getBestSuggestion`, `recomputeInlineSuggestion`, `applyAutoComplete`.
* `methodOptions` and `methodIndex` handle cycling logic.

## Notes

* Prefix-based matching (fuzzy later).
* No changes to other shortcuts.
* Re-added the `shift+tab` shortcut.

**Build: PASS**